### PR TITLE
Fixed the non-usage of calibration zero value

### DIFF
--- a/src/Q2Balance.cpp
+++ b/src/Q2Balance.cpp
@@ -190,7 +190,7 @@ float Q2Balance::calcValue(int units, long value){
   if (index == -1){
     return 0; //uncalibrated
   }
-  long val = _smoothValue - _tareValue;
+  long val = _smoothValue - _tareValue - _settings.calibrationZero;
   if (_tared){
     return (0);
   }


### PR DESCRIPTION
The Q2Balance::calcValue method does not use the calibration zero value which results in the impossibility to use existing calibration (from eeprom) an pre-loaded scales.

The change results in not having to call "tare()" on un-loaded scale prior to using it.
