### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,43 +6,43 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Q2Balance				KEYWORD1 Q2Balance
-BalanceCalibrationStruct  KEYWORD1  BalanceCalibrationStruct
+Q2Balance	KEYWORD1	Q2Balance
+BalanceCalibrationStruct	KEYWORD1	BalanceCalibrationStruct
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-TARELIMIT				KEYWORD2
-JUMPLIMIT				KEYWORD2
-SAMPLE_COUNT				KEYWORD2
-taring				KEYWORD2
-tared				KEYWORD2
-settling				KEYWORD2
-adjustedValue				KEYWORD2
-adjustedRawValue				KEYWORD2
-smoothValue				KEYWORD2
-rawValue				KEYWORD2
-jitter				KEYWORD2
-calibrateZero				KEYWORD2
-calibrate				KEYWORD2
-calibrating				KEYWORD2
-measure				KEYWORD2
-tare				KEYWORD2
-settle				KEYWORD2
-setCalibration				KEYWORD2
-tick				KEYWORD2
+TARELIMIT	KEYWORD2
+JUMPLIMIT	KEYWORD2
+SAMPLE_COUNT	KEYWORD2
+taring	KEYWORD2
+tared	KEYWORD2
+settling	KEYWORD2
+adjustedValue	KEYWORD2
+adjustedRawValue	KEYWORD2
+smoothValue	KEYWORD2
+rawValue	KEYWORD2
+jitter	KEYWORD2
+calibrateZero	KEYWORD2
+calibrate	KEYWORD2
+calibrating	KEYWORD2
+measure	KEYWORD2
+tare	KEYWORD2
+settle	KEYWORD2
+setCalibration	KEYWORD2
+tick	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-Q2BALANCE_MARKER_COUNT  LITERAL1
-Q2BALANCE_UNIT_GRAM  LITERAL1
-Q2BALANCE_UNIT_POUND  LITERAL1
-Q2BALANCE_UNIT_OUNCE  LITERAL1
-Q2BALANCE_UNIT_GRAIN  LITERAL1
-Q2BALANCE_UNIT_TROY  LITERAL1
-Q2BALANCE_UNIT_PWT  LITERAL1
-Q2BALANCE_UNIT_CARAT  LITERAL1
-Q2BALANCE_UNIT_NEWTON  LITERAL1
+Q2BALANCE_MARKER_COUNT	LITERAL1
+Q2BALANCE_UNIT_GRAM	LITERAL1
+Q2BALANCE_UNIT_POUND	LITERAL1
+Q2BALANCE_UNIT_OUNCE	LITERAL1
+Q2BALANCE_UNIT_GRAIN	LITERAL1
+Q2BALANCE_UNIT_TROY	LITERAL1
+Q2BALANCE_UNIT_PWT	LITERAL1
+Q2BALANCE_UNIT_CARAT	LITERAL1
+Q2BALANCE_UNIT_NEWTON	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords