### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,8 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Q2Balance	KEYWORD1	Q2Balance
-BalanceCalibrationStruct	KEYWORD1	BalanceCalibrationStruct
+Q2Balance	KEYWORD1
+BalanceCalibrationStruct	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language/Libraries Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format